### PR TITLE
Fix: remove unexpected `rspec help` output when running `rspec`.

### DIFF
--- a/exe/aoc
+++ b/exe/aoc
@@ -2,3 +2,5 @@
 # frozen_string_literal: true
 
 require "aoc_rb/cli"
+
+AocRb::Cli.start

--- a/lib/aoc_rb/app.rb
+++ b/lib/aoc_rb/app.rb
@@ -144,5 +144,3 @@ module AocRb
     end
   end
 end
-
-AocRb::App.start

--- a/lib/aoc_rb/cli.rb
+++ b/lib/aoc_rb/cli.rb
@@ -49,5 +49,3 @@ module AocRb
     end
   end
 end
-
-AocRb::Cli.start

--- a/templates/bin/aoc
+++ b/templates/bin/aoc
@@ -33,3 +33,5 @@ require "bundler/setup"
 # load Gem.bin_path("aoc_rb", "aoc")
 
 require 'aoc_rb/app'
+
+AocRb::App.start


### PR DESCRIPTION
Hi,

I've been having an issue that whenever I run `rspec` on the `aoc_rb` gem project, in addition to the spec results it also prints an unexpected "help" output which is kind of weird - it looks like it's for RSpec, but on a closer look it's actually for AocRb commands (but it says `rspec` instead of `aoc`).

This PR fixes it by moving `Thor.start` invocation to, what I hope is, a more appropriate place for it - the "bin" files.

---

### Expectation

When running `rspec` on this project I expect only the results of the specs to be printed.

```
$ rspec

AocRb::App
  fetch_input
    sends a GET request to AOC for today's input

...some output skipped...

12 examples, 0 failures
```

### Bug

When running `rspec` I also get the help output of the Thor commands, `AocRb::App` and `AocRb::Cli`. Also, weirdly, the help output states `rspec` instead of `aoc`.

```
$ rspec
Commands:
  rspec exec            # executes and optionally submits the puzzle for today, or the specified date
  rspec help [COMMAND]  # Describe available commands or one specific command
  rspec output          # outputs results from your solution for the given day
  rspec prep            # preps everything you need for a new puzzle
  rspec spec            # runs tests for today, or the specified date

Commands:
  rspec help [COMMAND]  # Describe available commands or one specific command
  rspec new NAME        # Creates a new AoC project with the given name


AocRb::App
  fetch_input
    sends a GET request to AOC for today's input

...some output skipped...

12 examples, 0 failures
```

### Fix

Moves `Thor.start` invocations from the respective class files to their respective "bin" files, so that `Thor.start` would no longer be called when `rspec` is loading the classes for the spec run.

---

Sorry if my description is terse. It's been a while since I contributed.