### PR TITLE
Allow day argument to be "0" padded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - No unreleased changes!
 
+## [0.2.10]
+### Changed
+- Update API handler to accept zero padded day numbers  ([#34](https://github.com/pacso/aoc_rb/pull/34) by [@YozuChris](https://github.com/YozuChris))
+
 ## [0.2.9]
 ### Changed
 - Added missing require to `lib/aoc_rb/app.rb` ([#33](https://github.com/pacso/aoc_rb/pull/33) by [@pacso](https://github.com/pacso))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release.
 
-[Unreleased]: https://github.com/pacso/aoc_rb/compare/v0.2.9...HEAD
+[Unreleased]: https://github.com/pacso/aoc_rb/compare/v0.2.10...HEAD
+[0.2.10]: https://github.com/pacso/aoc_rb/compare/v0.2.9...v0.2.10
 [0.2.9]: https://github.com/pacso/aoc_rb/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/pacso/aoc_rb/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/pacso/aoc_rb/compare/v0.2.6...v0.2.7

--- a/lib/aoc_rb/aoc_api.rb
+++ b/lib/aoc_rb/aoc_api.rb
@@ -24,7 +24,7 @@ module AocRb
 
     private
       def puzzle_path(year, day)
-        "/#{year}/day/#{day}"
+        "/#{year}/day/#{day.to_i}"
       end
 
       def input_path(year, day)

--- a/lib/aoc_rb/version.rb
+++ b/lib/aoc_rb/version.rb
@@ -1,3 +1,3 @@
 module AocRb
-  VERSION = "0.2.9"
+  VERSION = "0.2.10"
 end

--- a/spec/lib/aoc_rb/api_spec.rb
+++ b/spec/lib/aoc_rb/api_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe AocRb::AocApi do

--- a/spec/lib/aoc_rb/api_spec.rb
+++ b/spec/lib/aoc_rb/api_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AocRb::AocApi do
 
     it "requests the correct path for puzzle instructions with day #{day_input}" do
 
-      expected_path = "/#{year}/day/#{expected_day}"
+      expected_path = "/2024/day/1"
       
       allow(api.class).to receive(:get).and_return(double('Response', body: ''))
       
@@ -24,7 +24,7 @@ RSpec.describe AocRb::AocApi do
     end
 
     it "requests the correct path for puzzle input with day #{day_input}" do
-      expected_path = "/#{year}/day/#{expected_day}/input"
+      expected_path = "/2024/day/1/input"
 
       allow(api.class).to receive(:get).and_return(double('Response', body: ''))
 
@@ -35,7 +35,7 @@ RSpec.describe AocRb::AocApi do
     end
 
     it "posts to the correct path for submit_answer with day #{day_input}" do
-      expected_path = "/#{year}/day/#{expected_day}/answer"
+      expected_path = "/2024/day/1/answer"
       expected_body = { level: level.to_s, answer: answer.to_s }
 
       allow(api.class).to receive(:post).and_return(double('Response', body: ''))

--- a/spec/lib/aoc_rb/api_spec.rb
+++ b/spec/lib/aoc_rb/api_spec.rb
@@ -11,49 +11,58 @@ RSpec.describe AocRb::AocApi do
   shared_examples "consistent day path" do |day_input, expected_day|
     let(:expected_headers) { { 'Cookie' => "session=#{session_token}" } }
 
-    it "requests the correct path for puzzle instructions with day #{day_input}" do
+    describe "#puzzle_instructions" do
+      let(:expected_path) { "/2024/day/#{expected_day}" }
 
-      expected_path = "/2024/day/1"
-      
-      allow(api.class).to receive(:get).and_return(double('Response', body: ''))
-      
+      before do
+        allow(api.class).to receive(:get).and_return(double('Response', body: ''))
+      end
 
-      api.puzzle_instructions(year, day_input)
-      
-      expect(api.class).to have_received(:get).with(expected_path, hash_including(headers: expected_headers))
+      it "sends the request to the correct uri" do
+        api.puzzle_instructions(year, day_input)
+        expect(api.class).to have_received(:get).with(expected_path, hash_including(headers: expected_headers))
+      end
     end
 
-    it "requests the correct path for puzzle input with day #{day_input}" do
-      expected_path = "/2024/day/1/input"
+    describe "#puzzle_input" do
+      let(:expected_path) { "/2024/day/#{expected_day}/input" }
 
-      allow(api.class).to receive(:get).and_return(double('Response', body: ''))
+      before do
+        allow(api.class).to receive(:get).and_return(double('Response', body: ''))
+      end
 
-      api.puzzle_input(year, day_input)
-
-
-      expect(api.class).to have_received(:get).with(expected_path, hash_including(headers: expected_headers))
+      it "sends the request to the correct uri" do
+        api.puzzle_input(year, day_input)
+        expect(api.class).to have_received(:get).with(expected_path, hash_including(headers: expected_headers))
+      end
     end
 
-    it "posts to the correct path for submit_answer with day #{day_input}" do
-      expected_path = "/2024/day/1/answer"
-      expected_body = { level: level.to_s, answer: answer.to_s }
+    describe "#submit_answer" do
+      let(:expected_path) { "/2024/day/#{expected_day}/answer" }
+      let(:expected_body) { { level: level.to_s, answer: answer.to_s } }
 
-      allow(api.class).to receive(:post).and_return(double('Response', body: ''))
+      before do
+        allow(api.class).to receive(:post).and_return(double('Response', body: ''))
+      end
 
-      api.submit_answer(year, day_input, level, answer)
-
-
-      expect(api.class).to have_received(:post).with(expected_path, hash_including(headers: expected_headers, body: expected_body))
+      it "sends the request to the correct uri" do
+        api.submit_answer(year, day_input, level, answer)
+        expect(api.class).to have_received(:post).with(expected_path, hash_including(headers: expected_headers, body: expected_body))
+      end
     end
-
   end
 
-
-  context "when day is an integer (e.g., 1)" do
+  context "when day is an integer" do
     include_examples "consistent day path", 1, 1
+    include_examples "consistent day path", 17, 17
   end
 
-  context "when day is a string with leading zero (e.g., '01')" do
+  context "when day is a two-character string" do
     include_examples "consistent day path", "01", 1
+    include_examples "consistent day path", "22", 22
+  end
+
+  context "when day is a single character string" do
+    include_examples "consistent day path", "8", 8
   end
 end

--- a/spec/lib/aoc_rb/api_spec.rb
+++ b/spec/lib/aoc_rb/api_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe AocRb::AocApi do
+  let(:session_token) { "test_session_token" }
+  let(:year) { 2024 }
+  let(:level) { 1 }
+  let(:answer) { "42" }
+  let(:api) { described_class.new(session_token) }
+
+  shared_examples "consistent day path" do |day_input, expected_day|
+    let(:expected_headers) { { 'Cookie' => "session=#{session_token}" } }
+
+    it "requests the correct path for puzzle instructions with day #{day_input}" do
+
+      expected_path = "/#{year}/day/#{expected_day}"
+      
+      allow(api.class).to receive(:get).and_return(double('Response', body: ''))
+      
+
+      api.puzzle_instructions(year, day_input)
+      
+      expect(api.class).to have_received(:get).with(expected_path, hash_including(headers: expected_headers))
+    end
+
+    it "requests the correct path for puzzle input with day #{day_input}" do
+      expected_path = "/#{year}/day/#{expected_day}/input"
+
+      allow(api.class).to receive(:get).and_return(double('Response', body: ''))
+
+      api.puzzle_input(year, day_input)
+
+
+      expect(api.class).to have_received(:get).with(expected_path, hash_including(headers: expected_headers))
+    end
+
+    it "posts to the correct path for submit_answer with day #{day_input}" do
+      expected_path = "/#{year}/day/#{expected_day}/answer"
+      expected_body = { level: level.to_s, answer: answer.to_s }
+
+      allow(api.class).to receive(:post).and_return(double('Response', body: ''))
+
+      api.submit_answer(year, day_input, level, answer)
+
+
+      expect(api.class).to have_received(:post).with(expected_path, hash_including(headers: expected_headers, body: expected_body))
+    end
+
+  end
+
+
+  context "when day is an integer (e.g., 1)" do
+    include_examples "consistent day path", 1, 1
+  end
+
+  context "when day is a string with leading zero (e.g., '01')" do
+    include_examples "consistent day path", "01", 1
+  end
+end

--- a/spec/lib/aoc_rb_spec.rb
+++ b/spec/lib/aoc_rb_spec.rb
@@ -4,6 +4,6 @@ require 'spec_helper'
 
 RSpec.describe AocRb do
   it "has the expected version number" do
-    expect(AocRb::VERSION).to eq "0.2.9"
+    expect(AocRb::VERSION).to eq "0.2.10"
   end
 end


### PR DESCRIPTION
Currently, if you run a command with a "0" padded day argument for example: `aoc exec 2024 01` you'll get an error:

```
2024 Day 03
no result for part 1
Submit solution?  (y/N)
y
We said y
/home/chris/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/aoc_rb-0.2.9/lib/aoc_rb/puzzle_solution.rb:25:in `submit': undefined method `content' for nil (NoMethodError)

      puts articles[0].content
                      ^^^^^^^^
        from /home/chris/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/aoc_rb-0.2.9/lib/aoc_rb/app.rb:118:in `exec'
        from /home/chris/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
        from /home/chris/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
        from /home/chris/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor.rb:538:in `dispatch'
        from /home/chris/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor/base.rb:584:in `start'
        from bin/aoc:37:in `<main>'
```
        
This is because the arguments are passed in as strings to the command and so when the API is called, `puzzle_path` returns `/2024/day/01`, which is incorrect. I didn't expect this, especially since the challenge folders are 0 padded. 

Calling the command with options instead of arguments, for example: `aoc exec -y=2024 -d=01`, works as expected since `type: :numeric` normalises the option input to a numeric value.

This PR normalises the day input to a numeric value when generating the path, so `aoc exec 2024 01` and `aoc exec 2024 1` both work as expected.

Thanks!