### PR TITLE
Fix: using the gem under Ruby 3.4 prints a warning about future incompatibility.

### DIFF
--- a/aoc_rb.gemspec
+++ b/aoc_rb.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "benchmark", "~> 0.4"
   spec.add_dependency "dotenv", "~> 3.1"
   spec.add_dependency "httparty", "~> 0.22"
   spec.add_dependency "thor", "~> 1.3"


### PR DESCRIPTION
Starting from Ruby 3.5.0, `benchmark` gem will no longer be part of the default gems. In order to prepare for that, Ruby 3.4.0-rc1 prints a warning:

```
$ aoc
~/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/aoc_rb-0.2.10/lib/aoc_rb/app.rb:10: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add benchmark to your Gemfile or gemspec to silence this warning.
...
```
(interestingly, the warning seems slightly misleading, as the `benchmark` gem is actually required and used in `lib/aoc_rb/puzzle_source.rb`) 

This PR adds `benchmark` as an explicit dependency, and thus gets rid of the warning under Ruby 3.4, and prepares the gem for compatibility with Ruby 3.5.